### PR TITLE
Fix logo: use local og-image.jpg in nav, styled text in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,11 +6,9 @@ export default function Footer() {
       <div className="max-w-7xl mx-auto px-4">
         <div className="grid md:grid-cols-4 gap-8 mb-12">
           <div>
-            <img
-              src="https://ext.same-assets.com/4220051708/2409708753.png"
-              alt="EdgePredict"
-              className="h-8 mb-4 brightness-0 invert"
-            />
+            <div className="mb-4 text-xl font-bold tracking-tight">
+              <span className="text-purple-400">Edge</span><span className="text-white">Predict</span>
+            </div>
             <p className="text-gray-400 text-sm leading-relaxed">
               Non-invasive motor condition monitoring using Electrical Signature Analysis.
               Built for reliability engineers and maintenance managers.

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -20,9 +20,9 @@ export default function Nav() {
       <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
         <Link href="/" className="flex items-center">
           <img
-            src="https://ext.same-assets.com/4220051708/2409708753.png"
+            src="/og-image.jpg"
             alt="EdgePredict"
-            className="h-12"
+            className="h-12 w-auto"
           />
         </Link>
 


### PR DESCRIPTION
External same-assets.com URL was unreachable. Nav now uses /og-image.jpg (white bg works on white header). Footer uses a styled text lockup to avoid the white-background-on-dark issue with brightness-0 invert.